### PR TITLE
update to go-ipfs 0.4.15

### DIFF
--- a/convert/checks_test.go
+++ b/convert/checks_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/revert"
 	"github.com/ipfs/ipfs-ds-convert/testutil"
 
-	lock "gx/ipfs/QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe/lock"
+	lock "gx/ipfs/QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d/go4-lock"
 )
 
 func TestInvalidRepoVersion(t *testing.T) {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/revert"
 	"github.com/ipfs/ipfs-ds-convert/strategy"
 
-	lock "gx/ipfs/QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe/lock"
+	lock "gx/ipfs/QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d/go4-lock"
 )
 
 var Log = logging.New(os.Stderr, "convert ", logging.LstdFlags)

--- a/convert/copy.go
+++ b/convert/copy.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/strategy"
 
 	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
-	dsq "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore/query"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
+	dsq "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore/query"
 )
 
 type Copy struct {

--- a/convert/copy_test.go
+++ b/convert/copy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/repo"
 	"github.com/ipfs/ipfs-ds-convert/testutil"
 
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 )
 
 var (

--- a/package.json
+++ b/package.json
@@ -9,39 +9,39 @@
   "gxDependencies": [
     {
       "author": "jbenet",
-      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
+      "hash": "QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9",
       "name": "go-datastore",
-      "version": "1.4.0"
+      "version": "2.4.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmak5iFUErGmKhYUC5StZtCGFp5bdhvye8PdKgTMk9B9Fw",
+      "hash": "QmaCTqBCt1aKaGfHfSVzsprqWRXCjHthK8xXrPbUZYCWga",
       "name": "go-ds-flatfs",
-      "version": "1.1.5"
+      "version": "1.1.9"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmU7tt6mHJ5Wocjy2omBxpDfN8g9pkRimzJae7EXdrs96k",
+      "hash": "QmbJgZGRtkFeSdCxBCPaMKWRDYbqMxHyFfvjQGcWzpqsDe",
       "name": "go-ds-measure",
-      "version": "1.2.3"
+      "version": "1.3.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYnCBXxoyoS38vtNQjjpRwZTiUnpuuKpapxMNaDfyQRLf",
+      "hash": "QmVVhwMHaGHPgZY6pi8hbWGLSgMcZUSdEhJBChjxhBMCoy",
       "name": "go-ds-leveldb",
-      "version": "1.0.4"
+      "version": "1.0.6"
     },
     {
       "author": "magik6k",
-      "hash": "Qmdin8YL17fL1BC5ej6o9b8es6MBoiQjKVdyxEwJh3HVmf",
+      "hash": "QmPAiAmc3qhTFwzWnKpxr6WCXGZ5mqpaQ2YEwSTnwyduHo",
       "name": "go-ds-badger",
-      "version": "1.3.0"
+      "version": "1.4.5"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe",
+      "hash": "QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d",
       "name": "lock",
-      "version": "0.0.0"
+      "version": "0.0.2"
     },
     {
       "author": "syndtr",
@@ -51,26 +51,26 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTLGdJpFxjNTGqBkwTyhN3WeJteSjQPACmyxDjJ49V5NM",
+      "hash": "QmWND1EfMiRBWce8XAN5UhtuHvqDhskBpvJRRCgZoXGJTU",
       "name": "retry-datastore",
-      "version": "1.1.5"
+      "version": "1.1.7"
     },
     {
-      "hash": "QmdY9E5hA3pzMDW7w7gKEoioeDyvno3KnVwcvv3X3zEVVA",
+      "hash": "QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB",
       "name": "go-ipfs",
-      "version": "0.4.14-dev"
+      "version": "0.4.15"
     },
     {
       "author": "lgierth",
-      "hash": "QmS7xUmsTdVNU2t1bPV6o9aXuXfufAjNGYgh2bcN2z9DAs",
+      "hash": "QmQMRYmPn77CKRFf4YFjX3M5e6uw6DFAgsQffCX6mwZ4mA",
       "name": "go-multiaddr-dns",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     {
       "author": "multiformats",
-      "hash": "QmW8s4zTsUoX1Q6CeYxVKPyqSKbF7H1YDUyTostBtZ8DaG",
+      "hash": "QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb",
       "name": "go-multiaddr",
-      "version": "1.2.5"
+      "version": "1.2.6"
     }
   ],
   "gxVersion": "0.10.0",

--- a/repo/open.go
+++ b/repo/open.go
@@ -11,16 +11,16 @@ import (
 	"syscall"
 	"time"
 
-	measure "gx/ipfs/QmU7tt6mHJ5Wocjy2omBxpDfN8g9pkRimzJae7EXdrs96k/go-ds-measure"
-	flatfs "gx/ipfs/Qmak5iFUErGmKhYUC5StZtCGFp5bdhvye8PdKgTMk9B9Fw/go-ds-flatfs"
+	flatfs "gx/ipfs/QmaCTqBCt1aKaGfHfSVzsprqWRXCjHthK8xXrPbUZYCWga/go-ds-flatfs"
+	measure "gx/ipfs/QmbJgZGRtkFeSdCxBCPaMKWRDYbqMxHyFfvjQGcWzpqsDe/go-ds-measure"
 
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
-	mount "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore/syncmount"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
+	mount "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore/mount"
 
-	retry "gx/ipfs/QmTLGdJpFxjNTGqBkwTyhN3WeJteSjQPACmyxDjJ49V5NM/retry-datastore"
-	levelds "gx/ipfs/QmYnCBXxoyoS38vtNQjjpRwZTiUnpuuKpapxMNaDfyQRLf/go-ds-leveldb"
+	badgerds "gx/ipfs/QmPAiAmc3qhTFwzWnKpxr6WCXGZ5mqpaQ2YEwSTnwyduHo/go-ds-badger"
+	levelds "gx/ipfs/QmVVhwMHaGHPgZY6pi8hbWGLSgMcZUSdEhJBChjxhBMCoy/go-ds-leveldb"
+	retry "gx/ipfs/QmWND1EfMiRBWce8XAN5UhtuHvqDhskBpvJRRCgZoXGJTU/retry-datastore"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
-	badgerds "gx/ipfs/Qmdin8YL17fL1BC5ej6o9b8es6MBoiQjKVdyxEwJh3HVmf/go-ds-badger"
 )
 
 //TODO: extract and use fsrepo from go-ipfs

--- a/revert/revert.go
+++ b/revert/revert.go
@@ -11,8 +11,8 @@ import (
 
 	"encoding/json"
 	"github.com/ipfs/ipfs-ds-convert/config"
+	lock "gx/ipfs/QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d/go4-lock"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-	lock "gx/ipfs/QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe/lock"
 	"io/ioutil"
 )
 

--- a/revert/revert_test.go
+++ b/revert/revert_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/revert"
 	"github.com/ipfs/ipfs-ds-convert/testutil"
 
-	lock "gx/ipfs/QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe/lock"
+	lock "gx/ipfs/QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d/go4-lock"
 )
 
 func TestBasicConvertRevert(t *testing.T) {

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ipfs/ipfs-ds-convert/repo"
 
 	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 )
 
 var ErrMountNotSimple = errors.New("mount entry is not simple, mount datastores can't be nested")

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -212,7 +212,7 @@ func addMissingParents(specA SimpleMounts, specB SimpleMounts, specAOpt SimpleMo
 				ti := specA.hasPrefixed(bestMatch)
 				if ti == -1 {
 					//TODO: fallback to copyAll
-					return nil, nil, fmt.Errorf("couldn't find %s in specA, parent of %s", bestMatch.prefix.String(), mountA)
+					return nil, nil, fmt.Errorf("couldn't find %s in specA, parent of %s", bestMatch.prefix.String(), mountA.prefix.String())
 				}
 				specAOpt = append(specAOpt, specA[ti])
 			}

--- a/strategy/strategy_util.go
+++ b/strategy/strategy_util.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ipfs/ipfs-ds-convert/repo"
 
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 )
 
 type Spec map[string]interface{}

--- a/testutil/ds_utils.go
+++ b/testutil/ds_utils.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math/rand"
 
-	repo "gx/ipfs/QmdY9E5hA3pzMDW7w7gKEoioeDyvno3KnVwcvv3X3zEVVA/go-ipfs/repo"
-	fsrepo "gx/ipfs/QmdY9E5hA3pzMDW7w7gKEoioeDyvno3KnVwcvv3X3zEVVA/go-ipfs/repo/fsrepo"
+	repo "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/repo"
+	fsrepo "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/repo/fsrepo"
 
 	"bytes"
-	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 )
 
 func OpenRepo(repoPath string) (repo.Repo, error) {

--- a/testutil/repo.go
+++ b/testutil/repo.go
@@ -9,10 +9,10 @@ import (
 
 	conf "github.com/ipfs/ipfs-ds-convert/config"
 
-	madns "gx/ipfs/QmVHpaAVserMwuVXRJ7otLMro1D8qZQ5STSFfeK5eXTGy4/go-multiaddr-dns"
-	maddr "gx/ipfs/QmW8s4zTsUoX1Q6CeYxVKPyqSKbF7H1YDUyTostBtZ8DaG/go-multiaddr"
-	config "gx/ipfs/QmdY9E5hA3pzMDW7w7gKEoioeDyvno3KnVwcvv3X3zEVVA/go-ipfs/repo/config"
-	fsrepo "gx/ipfs/QmdY9E5hA3pzMDW7w7gKEoioeDyvno3KnVwcvv3X3zEVVA/go-ipfs/repo/fsrepo"
+	madns "gx/ipfs/QmQMRYmPn77CKRFf4YFjX3M5e6uw6DFAgsQffCX6mwZ4mA/go-multiaddr-dns"
+	maddr "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
+	config "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/repo/config"
+	fsrepo "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/repo/fsrepo"
 )
 
 //Hack
@@ -26,7 +26,7 @@ func NewTestRepo(t *testing.T, spec map[string]interface{}) (string, func(t *tes
 		t.Fatal(err)
 	}
 
-	err = config.Profiles["test"](conf)
+	err = config.Profiles["test"].Transform(conf)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
(using a version that's pinned)

Requires:

* [x] https://github.com/whyrusleeping/retry-datastore/pull/7
* [x] https://github.com/whyrusleeping/failstore/pull/8