### PR TITLE
Update the repo version from 6 to 7.

### DIFF
--- a/repo/const.go
+++ b/repo/const.go
@@ -5,6 +5,6 @@ const (
 	ConfigFile = "config"
 	SpecsFile  = "datastore_spec"
 
-	SuppertedRepoVersion = 6
+	SuppertedRepoVersion = 7
 	ToolVersion          = "0.1.1"
 )


### PR DESCRIPTION
By applying this simple fix the tool seems to be able to convert version 7 repos successfully. At least as far as i was testing it, agenst my own repo.