### PR TITLE
Bump SupportedRepoVersion to support go-ipfs 0.6.0

### DIFF
--- a/repo/const.go
+++ b/repo/const.go
@@ -5,6 +5,6 @@ const (
 	ConfigFile = "config"
 	SpecsFile  = "datastore_spec"
 
-	SupportedRepoVersion = 9
-	ToolVersion          = "0.1.1"
+	SupportedRepoVersion = 10
+	ToolVersion          = "0.1.2"
 )


### PR DESCRIPTION
This is the minimum required effort.
I made no attempt at testing.